### PR TITLE
피드 관련된 컴포넌트, 스크린, 템플릿과 추가적인 providers, compoents 추가

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,23 +1,29 @@
 import React from 'react';
 import { Provider as UserProvider } from 'context/User';
 import { Provider as AuthProvider } from 'context/Auth';
-import TrackPlayerProvider from 'providers/trackPlayer';
 import { Provider as AppleMusicProvider } from 'context/AppleMusic';
+import { Provider as RelayProvider } from 'context/Relay';
+import { Provider as PlaylistProvider } from 'context/Playlist';
+import { Provider as DailyProvider } from 'context/Daily';
+import ModalProvider from 'providers/modal';
 import MainNavigator from './src/navigation';
-import { Provider as RelayProvider } from './src/context/Relay';
 
 export default () => {
   return (
-    <TrackPlayerProvider>
+    <ModalProvider>
       <AppleMusicProvider>
         <UserProvider>
           <AuthProvider>
-            <RelayProvider>
-              <MainNavigator />
-            </RelayProvider>
+            <DailyProvider>
+              <PlaylistProvider>
+                <RelayProvider>
+                  <MainNavigator />
+                </RelayProvider>
+              </PlaylistProvider>
+            </DailyProvider>
           </AuthProvider>
         </UserProvider>
       </AppleMusicProvider>
-    </TrackPlayerProvider>
+    </ModalProvider>
   );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,10 +23,12 @@
         "react-native-gesture-handler": "2.1.0",
         "react-native-image-crop-picker": "0.37.2",
         "react-native-linear-gradient": "2.5.6",
+        "react-native-modal": "13.0.0",
         "react-native-reanimated": "2.3.1",
         "react-native-safe-area-context": "3.3.2",
         "react-native-screens": "^3.10.1",
         "react-native-swiper": "1.6.0",
+        "react-native-text-ticker": "1.14.0",
         "react-native-track-player": "2.1.2"
       },
       "devDependencies": {
@@ -12539,6 +12541,14 @@
         "react": "17.0.2"
       }
     },
+    "node_modules/react-native-animatable": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/react-native-animatable/-/react-native-animatable-1.3.3.tgz",
+      "integrity": "sha512-2ckIxZQAsvWn25Ho+DK3d1mXIgj7tITkrS4pYDvx96WyOttSvzzFeQnM2od0+FUMzILbdHDsDEqZvnz1DYNQ1w==",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      }
+    },
     "node_modules/react-native-codegen": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/react-native-codegen/-/react-native-codegen-0.0.7.tgz",
@@ -12575,6 +12585,19 @@
       "integrity": "sha512-HDwEaXcQIuXXCV70O+bK1rizFong3wj+5Q/jSyifKFLg0VWF95xh8XQgfzXwtq0NggL9vNjPKXa016KuFu+VFg==",
       "peerDependencies": {
         "react-native": ">=0.55"
+      }
+    },
+    "node_modules/react-native-modal": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-modal/-/react-native-modal-13.0.0.tgz",
+      "integrity": "sha512-k6r9T31mc7HIDFj1V53ceAAN1dwc8052c4JLtDVEmEQ19Bbq9yiLXoDsQuNb+hB8A+2tVOXmo5Gq4IQfb11upw==",
+      "dependencies": {
+        "prop-types": "^15.6.2",
+        "react-native-animatable": "1.3.3"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": ">=0.65.0"
       }
     },
     "node_modules/react-native-reanimated": {
@@ -12625,6 +12648,11 @@
       "dependencies": {
         "prop-types": "^15.5.10"
       }
+    },
+    "node_modules/react-native-text-ticker": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/react-native-text-ticker/-/react-native-text-ticker-1.14.0.tgz",
+      "integrity": "sha512-8TNGTcW43dfnCqIuXVA7F1Ny8SKGrw0pIrNS5nM7eda+6AsuPTZh3JQ2CwmSRYfsrlnS4QFrpyo5ykpI8nvtCw=="
     },
     "node_modules/react-native-track-player": {
       "version": "2.1.2",
@@ -24808,6 +24836,14 @@
         }
       }
     },
+    "react-native-animatable": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/react-native-animatable/-/react-native-animatable-1.3.3.tgz",
+      "integrity": "sha512-2ckIxZQAsvWn25Ho+DK3d1mXIgj7tITkrS4pYDvx96WyOttSvzzFeQnM2od0+FUMzILbdHDsDEqZvnz1DYNQ1w==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      }
+    },
     "react-native-codegen": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/react-native-codegen/-/react-native-codegen-0.0.7.tgz",
@@ -24841,6 +24877,15 @@
       "resolved": "https://registry.npmjs.org/react-native-linear-gradient/-/react-native-linear-gradient-2.5.6.tgz",
       "integrity": "sha512-HDwEaXcQIuXXCV70O+bK1rizFong3wj+5Q/jSyifKFLg0VWF95xh8XQgfzXwtq0NggL9vNjPKXa016KuFu+VFg==",
       "requires": {}
+    },
+    "react-native-modal": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-modal/-/react-native-modal-13.0.0.tgz",
+      "integrity": "sha512-k6r9T31mc7HIDFj1V53ceAAN1dwc8052c4JLtDVEmEQ19Bbq9yiLXoDsQuNb+hB8A+2tVOXmo5Gq4IQfb11upw==",
+      "requires": {
+        "prop-types": "^15.6.2",
+        "react-native-animatable": "1.3.3"
+      }
     },
     "react-native-reanimated": {
       "version": "2.3.1",
@@ -24878,6 +24923,11 @@
       "requires": {
         "prop-types": "^15.5.10"
       }
+    },
+    "react-native-text-ticker": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/react-native-text-ticker/-/react-native-text-ticker-1.14.0.tgz",
+      "integrity": "sha512-8TNGTcW43dfnCqIuXVA7F1Ny8SKGrw0pIrNS5nM7eda+6AsuPTZh3JQ2CwmSRYfsrlnS4QFrpyo5ykpI8nvtCw=="
     },
     "react-native-track-player": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -25,10 +25,12 @@
     "react-native-gesture-handler": "2.1.0",
     "react-native-image-crop-picker": "0.37.2",
     "react-native-linear-gradient": "2.5.6",
+    "react-native-modal": "13.0.0",
     "react-native-reanimated": "2.3.1",
     "react-native-safe-area-context": "3.3.2",
     "react-native-screens": "^3.10.1",
     "react-native-swiper": "1.6.0",
+    "react-native-text-ticker": "1.14.0",
     "react-native-track-player": "2.1.2"
   },
   "devDependencies": {

--- a/src/components/Feed/Contents.js
+++ b/src/components/Feed/Contents.js
@@ -1,0 +1,78 @@
+import React, { useContext, useState, useEffect } from 'react';
+import { View, FlatList, StyleSheet, ActivityIndicator } from 'react-native';
+import { Context as FeedContext } from 'context/Feed';
+import { Context as StoryContext } from 'context/Story';
+import Playlist from 'components/Feed/Playlist';
+import Daily from 'components/Feed/Daily';
+import Story from 'components/Feed/Story';
+import { useRefresh } from 'providers/refresh';
+import TrackPlayerProvider from 'providers/trackPlayer';
+import LoadingIndicator from 'components/LoadingIndicator';
+
+export default function Contents() {
+  const { state, nextFeeds, getFeeds } = useContext(FeedContext);
+  const { getMyStory, getOtherStoryWithAll } = useContext(StoryContext);
+  const { refreshing, onRefresh, setRefresh } = useRefresh();
+  const [loading, setLoading] = useState(false);
+
+  const getData = async () => {
+    if (state.feed.length >= 20 && !state.notNextFeed) {
+      setLoading(true);
+      await nextFeeds({ page: state.currentFeedPage });
+      setLoading(false);
+    }
+  };
+
+  const onEndReached = () => {
+    if (!loading) {
+      getData();
+    }
+  };
+
+  const fetchData = async () => {
+    await Promise.all([getFeeds(), getMyStory(), getOtherStoryWithAll()]);
+  };
+
+  useEffect(() => {
+    setRefresh(fetchData);
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      <TrackPlayerProvider>
+        {state.feed ? (
+          <FlatList
+            ListHeaderComponent={<Story />}
+            data={state.feed}
+            keyExtractor={(_) => _._id}
+            onEndReached={onEndReached}
+            onEndReachedThreshold={0.6}
+            onRefresh={onRefresh}
+            refreshing={refreshing}
+            ListFooterComponent={loading && <ActivityIndicator />}
+            renderItem={({ item }) => {
+              const { playlist, type, daily } = item;
+              return (
+                <>
+                  {type === 'playlist' ? (
+                    <Playlist playlist={playlist} type={type} />
+                  ) : (
+                    <Daily daily={daily} type={type} />
+                  )}
+                </>
+              );
+            }}
+          />
+        ) : (
+          <LoadingIndicator />
+        )}
+      </TrackPlayerProvider>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});

--- a/src/components/Feed/Daily.js
+++ b/src/components/Feed/Daily.js
@@ -1,0 +1,54 @@
+import React, { useContext } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import FS, { SCALE_HEIGHT, SCALE_WIDTH } from 'lib/utils/normalize';
+import PostUser from './PostUser';
+import Footer from './Footer';
+import DailyImage from './DailyImage';
+// import DailySong from './DailySong';
+
+export default function Daily({ daily, type }) {
+  const {
+    _id: id,
+    hashtag,
+    comments,
+    likes,
+    postUserId: postUser,
+    song,
+    textcontent: content,
+    image,
+  } = daily;
+
+  return (
+    <View style={styles.container}>
+      <PostUser user={postUser} />
+      {image.length > 0 && <DailyImage image={image} />}
+      <TouchableOpacity style={styles.contentArea}>
+        <Text style={styles.content} numberOfLines={3}>
+          {content}
+        </Text>
+      </TouchableOpacity>
+      <Footer hashtag={hashtag} likes={likes} comments={comments} id={id} type={type} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    borderBottomWidth: 1 * SCALE_WIDTH,
+    borderBottomColor: '#dcdcdc',
+    paddingBottom: 4 * SCALE_HEIGHT,
+  },
+  contentArea: {
+    paddingHorizontal: 18 * SCALE_WIDTH,
+    paddingTop: 8 * SCALE_HEIGHT,
+  },
+  content: {
+    fontSize: FS(14),
+    fontWeight: '500',
+    lineHeight: 24 * SCALE_HEIGHT,
+  },
+  songsContainer: {
+    paddingLeft: 18 * SCALE_WIDTH,
+    marginTop: 6 * SCALE_HEIGHT,
+  },
+});

--- a/src/components/Feed/DailyImage.js
+++ b/src/components/Feed/DailyImage.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { StyleSheet, Image } from 'react-native';
+import { SCALE_HEIGHT, SCALE_WIDTH } from 'lib/utils/normalize';
+import Swiper from 'react-native-swiper';
+
+export default function Dailyimage({ image }) {
+  return (
+    <Swiper height={375 * SCALE_WIDTH} loop={false}>
+      {image.map((img) => {
+        return <Image source={{ uri: img }} style={styles.img} key={img} />;
+      })}
+    </Swiper>
+  );
+}
+
+const styles = StyleSheet.create({
+  img: {
+    marginTop: 10 * SCALE_HEIGHT,
+    width: 375 * SCALE_WIDTH,
+    height: 375 * SCALE_WIDTH,
+  },
+});

--- a/src/components/Feed/Footer.js
+++ b/src/components/Feed/Footer.js
@@ -1,0 +1,95 @@
+import React, { useContext, useState } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, Image } from 'react-native';
+import { Context as UserContext } from 'context/User';
+import { Context as PlaylistContext } from 'context/Playlist';
+import { Context as DailyContext } from 'context/Daily';
+import FS, { SCALE_HEIGHT, SCALE_WIDTH } from 'lib/utils/normalize';
+import style from 'constants/styles';
+
+export default function Footer({ hashtag, likes, comments, id, type }) {
+  const { state } = useContext(UserContext);
+  const { likesPlaylist, unlikesPlaylist } = useContext(PlaylistContext);
+  const { likesDaily, unlikesDaily } = useContext(DailyContext);
+  const [isLike, setIsLike] = useState(likes.includes(state.user._id));
+
+  const onClickLikes = () => {
+    if (isLike) {
+      if (type === 'playlist') {
+        unlikesPlaylist({ id });
+      } else {
+        unlikesDaily({ id });
+      }
+    } else if (type === 'playlist') {
+      likesPlaylist({ id });
+    } else {
+      likesDaily({ id });
+    }
+    setIsLike(!isLike);
+  };
+
+  return (
+    <View style={[styles.container, hashtag.length !== 0 && styles.isHashtag]}>
+      <View style={[style.space_between, style.flexRow]}>
+        <View>
+          <View style={[style.flexRow, styles.wrap]}>
+            {hashtag.map((item) => (
+              <View style={styles.box} key={item}>
+                <Text style={styles.hashtag}>#{item}</Text>
+              </View>
+            ))}
+          </View>
+          <View style={[style.flexRow, hashtag.length === 0 && styles.isHashtag]}>
+            <View style={styles.icon} />
+            <Text style={styles.indicator}>{likes.length}</Text>
+            <View style={styles.icon} />
+            <Text style={styles.indicator}>{comments.length}</Text>
+          </View>
+        </View>
+        <TouchableOpacity onPress={onClickLikes}>
+          <View style={styles.heart} />
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 18 * SCALE_WIDTH,
+  },
+  isHashtag: {
+    marginTop: 14 * SCALE_HEIGHT,
+  },
+  box: {
+    borderRadius: 100 * SCALE_HEIGHT,
+    borderWidth: 1 * SCALE_WIDTH,
+    borderColor: '#8bc0ff',
+    marginRight: 8 * SCALE_WIDTH,
+  },
+  hashtag: {
+    paddingHorizontal: 11 * SCALE_WIDTH,
+    paddingVertical: 4 * SCALE_HEIGHT,
+    color: '#8bc0ff',
+    fontWeight: '400',
+    fontSize: FS(14),
+  },
+  wrap: {
+    flexWrap: 'wrap',
+  },
+  icon: {
+    width: 40 * SCALE_WIDTH,
+    height: 40 * SCALE_WIDTH,
+    marginTop: 4 * SCALE_HEIGHT,
+    borderWidth: 1,
+  },
+  indicator: {
+    fontWeight: '400',
+    fontSize: FS(12),
+    marginLeft: -5 * SCALE_WIDTH,
+  },
+  heart: {
+    width: 50 * SCALE_WIDTH,
+    height: 50 * SCALE_WIDTH,
+    borderWidth: 1,
+  },
+});

--- a/src/components/Feed/Playlist.js
+++ b/src/components/Feed/Playlist.js
@@ -1,0 +1,47 @@
+import React, { useContext } from 'react';
+import { Text, StyleSheet, View, TouchableOpacity } from 'react-native';
+import FS, { SCALE_HEIGHT, SCALE_WIDTH } from 'lib/utils/normalize';
+import { Context as PlaylistContext } from '../../context/Playlist';
+import PostUser from './PostUser';
+import SongsLists from './SongsLists';
+import Footer from './Footer';
+
+export default function Playlist({ playlist, type }) {
+  const { _id: id, hashtag, comments, likes, postUserId: postUser, songs, title } = playlist;
+  const { getPlaylist } = useContext(PlaylistContext);
+
+  const onClickPlaylist = async () => {
+    // await getPlaylist({ id, postUserId: postUser._id });
+    // push('SelectedPlaylist', { id, postUser: postUser._id });
+  };
+
+  return (
+    <TouchableOpacity style={styles.container} onPress={onClickPlaylist}>
+      <PostUser user={postUser} />
+      <View style={styles.contentArea}>
+        <Text style={styles.content} numberOfLines={3}>
+          {title}
+        </Text>
+      </View>
+      <SongsLists songs={songs} />
+      <Footer hashtag={hashtag} likes={likes} comments={comments} id={id} type={type} />
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    borderBottomWidth: 1 * SCALE_WIDTH,
+    borderBottomColor: '#dcdcdc',
+    paddingBottom: 4 * SCALE_HEIGHT,
+  },
+  contentArea: {
+    paddingHorizontal: 18 * SCALE_WIDTH,
+    marginTop: 8 * SCALE_HEIGHT,
+  },
+  content: {
+    fontSize: FS(14),
+    fontWeight: '500',
+    lineHeight: 24 * SCALE_HEIGHT,
+  },
+});

--- a/src/components/Feed/PostUser.js
+++ b/src/components/Feed/PostUser.js
@@ -1,0 +1,46 @@
+import React, { useContext } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import ProfileImage from 'widgets/ProfileImage';
+import { navigate, push } from 'lib/utils/navigation';
+import FS, { SCALE_HEIGHT, SCALE_WIDTH } from 'lib/utils/normalize';
+
+export default function PostUser({ user }) {
+  const { _id: id, profileImage: img, name } = user;
+
+  const onClickProfile = async () => {
+    // if (id === state.myInfo._id) {
+    //  navigate('Account');
+    // } else {
+    //  await Promise.all([getOtheruser({ id }), getSongs({ id })]);
+    //  push('OtherAccount', { otherUserId: id });
+    // }
+  };
+
+  return (
+    <View style={styles.container}>
+      <TouchableOpacity onPress={onClickProfile}>
+        <ProfileImage img={img} imgStyle={styles.profileImg} />
+      </TouchableOpacity>
+      <Text style={styles.name}>{name}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 9 * SCALE_HEIGHT,
+    paddingLeft: 18 * SCALE_WIDTH,
+  },
+  profileImg: {
+    width: 40 * SCALE_WIDTH,
+    height: 40 * SCALE_WIDTH,
+    borderRadius: 40 * SCALE_HEIGHT,
+    marginRight: 11 * SCALE_WIDTH,
+  },
+  name: {
+    fontSize: FS(14),
+    fontWeight: '400',
+  },
+});

--- a/src/components/Feed/SongsLists.js
+++ b/src/components/Feed/SongsLists.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import { View, StyleSheet, TouchableOpacity, FlatList } from 'react-native';
+import { SongImage } from 'widgets/SongImage';
+import { useTrackPlayer } from 'providers/trackPlayer';
+import MoveText from 'components/MoveText';
+import FS, { SCALE_HEIGHT, SCALE_WIDTH } from 'lib/utils/normalize';
+
+export default function SongLists({ songs }) {
+  const { isPlayingId, onClickSong } = useTrackPlayer();
+
+  return (
+    <FlatList
+      contentContainerStyle={styles.songsContainer}
+      data={songs}
+      keyExtractor={(playlist) => playlist.id}
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      renderItem={({ item }) => {
+        const { attributes, id } = item;
+        const { url } = item.attributes.artwork;
+        const { contentRating, name, artistName } = attributes;
+        return (
+          <View>
+            <TouchableOpacity onPress={() => onClickSong(item)} activeOpacity={0.9}>
+              <SongImage url={url} imgStyle={styles.playlistsImg} />
+            </TouchableOpacity>
+            <MoveText
+              isExplicit={contentRating === 'explicit'}
+              container={contentRating === 'explicit' ? styles.explicitName : styles.nameBox}
+              text={name}
+              isMove={id === isPlayingId}
+              textStyle={styles.name}
+            />
+            <MoveText
+              container={styles.artistBox}
+              text={artistName}
+              isMove={id === isPlayingId}
+              textStyle={styles.artist}
+            />
+          </View>
+        );
+      }}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  songsContainer: {
+    paddingLeft: 18 * SCALE_WIDTH,
+    marginTop: 6 * SCALE_HEIGHT,
+  },
+  playlistsImg: {
+    width: 120 * SCALE_WIDTH,
+    height: 120 * SCALE_WIDTH,
+    borderRadius: 4 * SCALE_WIDTH,
+    borderWidth: 0.5 * SCALE_WIDTH,
+    borderColor: '#e3e3e3',
+    marginRight: 8 * SCALE_WIDTH,
+  },
+  nameBox: {
+    marginTop: 9 * SCALE_HEIGHT,
+    width: 117 * SCALE_WIDTH,
+  },
+  explicitName: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 9 * SCALE_HEIGHT,
+    width: 95 * SCALE_WIDTH,
+  },
+  artistBox: {
+    width: 110 * SCALE_WIDTH,
+  },
+  name: {
+    fontSize: FS(14),
+    lineHeight: 16 * SCALE_HEIGHT,
+  },
+  artist: {
+    fontSize: FS(13),
+    color: '#838383',
+    marginTop: 4 * SCALE_HEIGHT,
+  },
+  playIcon: {
+    position: 'absolute',
+    right: 6 * SCALE_WIDTH,
+    bottom: 6 * SCALE_HEIGHT,
+  },
+});

--- a/src/components/Feed/Story.js
+++ b/src/components/Feed/Story.js
@@ -1,0 +1,108 @@
+import React, { useContext } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+  ImageBackground,
+} from 'react-native';
+import { Context as UserContext } from 'context/User';
+import { Context as StoryContext } from 'context/Story';
+import FS, { SCALE_WIDTH, SCALE_HEIGHT } from 'lib/utils/normalize';
+import ProfileImage from 'widgets/ProfileImage';
+
+export default function Story() {
+  const { state } = useContext(StoryContext);
+  const { state: userState } = useContext(UserContext);
+  const { user } = userState;
+
+  return (
+    <View style={styles.container}>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.scrollContainer}
+      >
+        <View style={styles.nameArea}>
+          {state.myStory ? (
+            <TouchableOpacity style={styles.story}>
+              {state.storyViewer.includes(user._id) ? (
+                <ProfileImage img={user.profileImage} imgStyle={styles.profileImg} />
+              ) : (
+                <ImageBackground>
+                  <ProfileImage img={user.profileImage} imgStyle={styles.profileImg} />
+                </ImageBackground>
+              )}
+            </TouchableOpacity>
+          ) : (
+            <TouchableOpacity style={styles.story}>
+              <ProfileImage img={user.profileImage} imgStyle={styles.profileImg} />
+            </TouchableOpacity>
+          )}
+          <Text numberOfLines={1} style={styles.name}>
+            {user.name}
+          </Text>
+        </View>
+        {state.otherStoryLists &&
+          state.otherStoryLists.map((item, index) => {
+            const { song, view, _id: id } = item;
+            const { profileImage, name } = item.postUserId;
+            return (
+              <View style={styles.nameArea} key={id}>
+                <TouchableOpacity style={styles.story}>
+                  {view.includes(user._id) ? (
+                    <ProfileImage img={profileImage} imgStyle={styles.profileImg} />
+                  ) : (
+                    <ImageBackground style={styles.story}>
+                      <ProfileImage img={profileImage} imgStyle={styles.profileImg} />
+                    </ImageBackground>
+                  )}
+                </TouchableOpacity>
+                <Text numberOfLines={1} style={styles.name}>
+                  {name}
+                </Text>
+              </View>
+            );
+          })}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingBottom: 10 * SCALE_HEIGHT,
+    borderBottomWidth: 1 * SCALE_HEIGHT,
+    borderBottomColor: '#dcdcdc',
+  },
+  scrollContainer: {
+    paddingHorizontal: 18 * SCALE_WIDTH,
+  },
+  story: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: 60 * SCALE_WIDTH,
+    height: 60 * SCALE_WIDTH,
+  },
+  profileImg: {
+    width: 56 * SCALE_WIDTH,
+    height: 56 * SCALE_WIDTH,
+    borderRadius: 56 * SCALE_HEIGHT,
+  },
+  plus: {
+    position: 'absolute',
+    bottom: 0,
+    right: 0,
+  },
+  name: {
+    fontSize: FS(11),
+    fontWeight: '400',
+    marginTop: 8 * SCALE_HEIGHT,
+    textAlign: 'center',
+  },
+  nameArea: {
+    width: 60 * SCALE_WIDTH,
+    marginRight: 16 * SCALE_WIDTH,
+  },
+});

--- a/src/components/LoadingIndicator/index.js
+++ b/src/components/LoadingIndicator/index.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View, ActivityIndicator, StyleSheet } from 'react-native';
+
+export default function LoadingIndicator() {
+  return (
+    <View style={styles.container}>
+      <ActivityIndicator />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/src/components/Modal/HarmfulModal.js
+++ b/src/components/Modal/HarmfulModal.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { useModal } from 'providers/modal';
+import FS, { SCALE_WIDTH, SCALE_HEIGHT } from 'lib/utils/normalize';
+import Modal from '.';
+
+const ModalView = () => {
+  const { onCloseModal } = useModal();
+  return (
+    <View style={styles.viewContainer}>
+      <Text style={styles.title}>유해성 컨텐츠는 현재 감상할 수 없습니다.</Text>
+      <TouchableOpacity onPress={onCloseModal}>
+        <Text style={styles.complete}>확인</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+export default function HarmfulModal() {
+  const { isModal, onCloseModal } = useModal();
+
+  return (
+    <Modal isVisible={isModal} onBackdropPress={onCloseModal} style={styles.container}>
+      <ModalView />
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    margin: 0,
+    alignItems: 'center',
+  },
+  viewContainer: {
+    width: 305 * SCALE_WIDTH,
+    height: 94 * SCALE_HEIGHT,
+    backgroundColor: 'rgb(254,254,254)',
+    borderRadius: 8 * SCALE_HEIGHT,
+    alignItems: 'center',
+  },
+  title: {
+    fontSize: FS(16),
+    color: 'rgb(86,86,86)',
+    marginTop: 24 * SCALE_HEIGHT,
+  },
+  complete: {
+    fontSize: FS(16),
+    marginTop: 16 * SCALE_HEIGHT,
+  },
+});

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import Modal from 'react-native-modal';
+
+export default function ({ children, ...props }) {
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <Modal animationIn="fadeIn" animationOut="fadeOut" backdropOpacity={0.4} {...props}>
+      {children}
+    </Modal>
+  );
+}

--- a/src/components/MoveText/index.js
+++ b/src/components/MoveText/index.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import TextTicker from 'react-native-text-ticker';
+import style from 'constants/styles';
+import { SCALE_WIDTH } from 'lib/utils/normalize';
+
+export default function MoveText({ container, text, isMove, isExplicit, textStyle }) {
+  return (
+    <View style={container}>
+      <View style={style.flexRow}>
+        {isExplicit && <View style={styles.explicit} />}
+        {isMove ? (
+          <TextTicker duration={7000} bounce={false} marqueeDelay={1000} style={textStyle}>
+            {text}
+          </TextTicker>
+        ) : (
+          <Text style={textStyle} numberOfLines={1}>
+            {text}
+          </Text>
+        )}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  explicit: {
+    width: 12 * SCALE_WIDTH,
+    height: 12 * SCALE_WIDTH,
+    borderWidth: 1 * SCALE_WIDTH,
+    marginRight: 5 * SCALE_WIDTH,
+  },
+});

--- a/src/components/SongTitle.js/index.js
+++ b/src/components/SongTitle.js/index.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Text, View, StyleSheet } from 'react-native';
+import style from 'constants/styles';
+import { SCALE_WIDTH } from 'lib/utils/normalize';
+
+export default function SongTitle({ isExplicit, title, titleStyle }) {
+  return (
+    <View style={style.flexRow}>
+      {isExplicit && <View style={styles.explicit} />}
+      <Text style={titleStyle} numberOfLines={1}>
+        {title}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  explicit: {
+    width: 12 * SCALE_WIDTH,
+    height: 12 * SCALE_WIDTH,
+    borderWidth: 1 * SCALE_WIDTH,
+    marginRight: 5 * SCALE_WIDTH,
+  },
+});

--- a/src/navigation/Main/Tab.js
+++ b/src/navigation/Main/Tab.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 
 import Relay from 'screens/Main/Relay';
+import Feed from 'screens/Main/Feed';
 
 const Tab = createBottomTabNavigator();
 
@@ -12,6 +13,7 @@ const TabScreen = () => (
     })}
   >
     <Tab.Screen name="Relay" component={Relay} />
+    <Tab.Screen name="Feed" component={Feed} />
     {/*
     <Tab.Screen name="Feed" component={MainFeedPage} />
     <Tab.Screen

--- a/src/navigation/index.js
+++ b/src/navigation/index.js
@@ -4,6 +4,7 @@ import navigationRef from 'lib/utils/navigation';
 import { Context as AuthContext } from 'context/Auth';
 import Splash from 'screens/Main/Splash';
 import { StatusBar } from 'react-native';
+import HarmfulModal from 'components/Modal/HarmfulModal';
 import MainStackScreen from './Main';
 import AuthStackScreen from './Auth';
 
@@ -22,6 +23,7 @@ const MainNavigator = () => {
     <NavigationContainer ref={navigationRef}>
       <StatusBar />
       {authState.token ? <MainStackScreen /> : <AuthStackScreen />}
+      <HarmfulModal />
     </NavigationContainer>
   );
 };

--- a/src/providers/modal/index.js
+++ b/src/providers/modal/index.js
@@ -1,0 +1,21 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const ModalContext = createContext(null);
+
+export const useModal = () => useContext(ModalContext);
+
+export default function ModalProvider({ children }) {
+  const [isModal, setIsModal] = useState(false);
+
+  const onCloseModal = () => {
+    setIsModal(false);
+  };
+
+  const value = {
+    isModal,
+    setIsModal,
+    onCloseModal,
+  };
+
+  return <ModalContext.Provider value={value}>{children}</ModalContext.Provider>;
+}

--- a/src/providers/refresh/index.js
+++ b/src/providers/refresh/index.js
@@ -1,0 +1,34 @@
+import React, { createContext, useContext, useState, useRef } from 'react';
+
+const RefreshContext = createContext(null);
+
+export const useRefresh = () => useContext(RefreshContext);
+
+export default function RefreshProvider({ children }) {
+  const [refreshing, setRefreshing] = useState(false);
+  const refreshRef = useRef();
+
+  const fetchData = async () => {
+    setRefreshing(true);
+    await refreshRef.current.call();
+    setRefreshing(false);
+  };
+
+  const onRefresh = () => {
+    if (!refreshing) {
+      fetchData();
+    }
+  };
+
+  const setRefresh = (callback) => {
+    refreshRef.current = callback;
+  };
+
+  const value = {
+    refreshing,
+    onRefresh,
+    setRefresh,
+  };
+
+  return <RefreshContext.Provider value={value}>{children}</RefreshContext.Provider>;
+}

--- a/src/providers/trackPlayer/index.js
+++ b/src/providers/trackPlayer/index.js
@@ -1,18 +1,17 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
-// import { useModal } from 'providers/modal';
+import { useModal } from 'providers/modal';
 import TrackPlayer, { useProgress } from 'react-native-track-player';
 
 const TrackPlayerContext = createContext(null);
 
 export const useTrackPlayer = () => useContext(TrackPlayerContext);
 
-const TrackPlayerProvider = ({ children }) => {
+export default function TrackPlayerProvider({ children }) {
   const [isPlayingId, setIsPlayingId] = useState('0');
   const [currentSong, setCurrentSong] = useState(null);
   const [isMute, setIsMute] = useState(false);
-  // const { setHarmfulModal } = useModal();
+  const { setIsModal } = useModal();
   const { position, duration } = useProgress();
-
   const addtracksong = async ({ data }) => {
     data.attributes.artwork.url = data.attributes.artwork.url.replace('{w}', '300');
     data.attributes.artwork.url = data.attributes.artwork.url.replace('{h}', '300');
@@ -43,7 +42,7 @@ const TrackPlayerProvider = ({ children }) => {
       await TrackPlayer.add(track);
       TrackPlayer.play();
     } else {
-      // setHarmfulModal(true);
+      setIsModal(true);
     }
     setCurrentSong(data);
   };
@@ -90,6 +89,4 @@ const TrackPlayerProvider = ({ children }) => {
   }, [isPlayingId, duration, position]);
 
   return <TrackPlayerContext.Provider value={value}>{children}</TrackPlayerContext.Provider>;
-};
-
-export default TrackPlayerProvider;
+}

--- a/src/screens/Main/Feed/index.js
+++ b/src/screens/Main/Feed/index.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import StatusBar from 'components/StatusBar';
+import Feed from 'templates/Main/Feed';
+import { Provider as FeedProvder } from 'context/Feed';
+import { Provider as StoryProvider } from 'context/Story';
+
+export default function () {
+  return (
+    <>
+      <StatusBar />
+      <StoryProvider>
+        <FeedProvder>
+          <Feed />
+        </FeedProvder>
+      </StoryProvider>
+    </>
+  );
+}

--- a/src/screens/Main/Relay/SwipeScreen.js
+++ b/src/screens/Main/Relay/SwipeScreen.js
@@ -1,6 +1,11 @@
 import React from 'react';
 import Swipe from 'templates/Main/Relay/Swipe';
+import TrackPlayerProvider from 'providers/trackPlayer';
 
 export default function () {
-  return <Swipe />;
+  return (
+    <TrackPlayerProvider>
+      <Swipe />
+    </TrackPlayerProvider>
+  );
 }

--- a/src/templates/Main/Feed/index.js
+++ b/src/templates/Main/Feed/index.js
@@ -1,0 +1,38 @@
+import React, { useContext, useEffect } from 'react';
+import { View, StyleSheet } from 'react-native';
+import style from 'constants/styles';
+import TabTitle from 'components/TabTitle';
+import { Context as FeedContext } from 'context/Feed';
+import { Context as StoryContext } from 'context/Story';
+import Contents from 'components/Feed/Contents';
+import FS, { SCALE_HEIGHT, SCALE_WIDTH } from 'lib/utils/normalize';
+import RefreshProvider from 'providers/refresh';
+
+export default function Feed() {
+  const { getFeeds } = useContext(FeedContext);
+  const { getMyStory, getOtherStoryWithAll } = useContext(StoryContext);
+
+  useEffect(() => {
+    getFeeds();
+    getMyStory();
+    getOtherStoryWithAll();
+  }, []);
+
+  return (
+    <View style={style.background}>
+      <TabTitle title="피드" titleStyle={styles.title} />
+      <RefreshProvider>
+        <Contents />
+      </RefreshProvider>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  title: {
+    fontSize: FS(24),
+    fontWeight: '500',
+    marginLeft: 18 * SCALE_WIDTH,
+    marginBottom: 6 * SCALE_HEIGHT,
+  },
+});

--- a/src/templates/Main/Relay/SelectedRelay.js
+++ b/src/templates/Main/Relay/SelectedRelay.js
@@ -7,6 +7,7 @@ import Divider from 'widgets/Divider';
 import MusicSection from 'components/Relay/MusicSection';
 import NavButton from 'components/Relay/NavButton';
 import { useFocusEffect } from '@react-navigation/native';
+import TrackPlayerProvider from 'providers/trackPlayer';
 
 export default function ({ id }) {
   const { getSelectedRelay, getRelaySong, state } = useContext(RelayContext);
@@ -21,7 +22,7 @@ export default function ({ id }) {
   return (
     <View style={style.background}>
       {state.selectedRelay && state.swipeSongs && (
-        <>
+        <TrackPlayerProvider>
           <Information information={state.selectedRelay.playlist} />
           <Divider />
           <MusicSection
@@ -31,7 +32,7 @@ export default function ({ id }) {
           <Divider />
           <MusicSection title="실시간 상위 곡" songs={state.selectedRelay.songs} />
           <NavButton isSwipe={state.swipeSongs.length > 0} />
-        </>
+        </TrackPlayerProvider>
       )}
     </View>
   );

--- a/src/widgets/SongImage.js
+++ b/src/widgets/SongImage.js
@@ -5,7 +5,7 @@ import { SCALE_HEIGHT } from 'lib/utils/normalize';
 const SongImage = ({ url, imgStyle }) => {
   url = url.replace('{w}', '300');
   url = url.replace('{h}', '300');
-  return <Image style={imgStyle} source={{ url }} />;
+  return <Image style={imgStyle} source={{ uri: url }} />;
 };
 
 const SongImageBack = ({ url, imgStyle, border }) => {
@@ -15,7 +15,7 @@ const SongImageBack = ({ url, imgStyle, border }) => {
     <ImageBackground
       style={imgStyle}
       resizeMode="stretch"
-      source={{ url }}
+      source={{ uri: url }}
       imageStyle={{ borderRadius: border * SCALE_HEIGHT }}
     />
   );
@@ -28,7 +28,7 @@ const SongImageBackStory = ({ url, imgStyle, border }) => {
     <ImageBackground
       style={imgStyle}
       resizeMode="contain"
-      source={{ url }}
+      source={{ uri: url }}
       imageStyle={{ borderRadius: border * SCALE_HEIGHT }}
     />
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -6240,7 +6240,7 @@
     "kleur" "^3.0.3"
     "sisteransi" "^1.0.5"
 
-"prop-types@^15.5.10", "prop-types@^15.7.2":
+"prop-types@^15.5.10", "prop-types@^15.6.2", "prop-types@^15.7.2":
   "integrity" "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ=="
   "resolved" "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz"
   "version" "15.7.2"
@@ -6310,6 +6310,13 @@
   "resolved" "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz"
   "version" "17.0.2"
 
+"react-native-animatable@1.3.3":
+  "integrity" "sha512-2ckIxZQAsvWn25Ho+DK3d1mXIgj7tITkrS4pYDvx96WyOttSvzzFeQnM2od0+FUMzILbdHDsDEqZvnz1DYNQ1w=="
+  "resolved" "https://registry.npmjs.org/react-native-animatable/-/react-native-animatable-1.3.3.tgz"
+  "version" "1.3.3"
+  dependencies:
+    "prop-types" "^15.7.2"
+
 "react-native-codegen@^0.0.7":
   "integrity" "sha512-dwNgR8zJ3ALr480QnAmpTiqvFo+rDtq6V5oCggKhYFlRjzOmVSFn3YD41u8ltvKS5G2nQ8gCs2vReFFnRGLYng=="
   "resolved" "https://registry.npmjs.org/react-native-codegen/-/react-native-codegen-0.0.7.tgz"
@@ -6339,6 +6346,14 @@
   "integrity" "sha512-HDwEaXcQIuXXCV70O+bK1rizFong3wj+5Q/jSyifKFLg0VWF95xh8XQgfzXwtq0NggL9vNjPKXa016KuFu+VFg=="
   "resolved" "https://registry.npmjs.org/react-native-linear-gradient/-/react-native-linear-gradient-2.5.6.tgz"
   "version" "2.5.6"
+
+"react-native-modal@13.0.0":
+  "integrity" "sha512-k6r9T31mc7HIDFj1V53ceAAN1dwc8052c4JLtDVEmEQ19Bbq9yiLXoDsQuNb+hB8A+2tVOXmo5Gq4IQfb11upw=="
+  "resolved" "https://registry.npmjs.org/react-native-modal/-/react-native-modal-13.0.0.tgz"
+  "version" "13.0.0"
+  dependencies:
+    "prop-types" "^15.6.2"
+    "react-native-animatable" "1.3.3"
 
 "react-native-reanimated@2.3.1":
   "integrity" "sha512-nzjVqwkB8eeyPKT2KoiA9EEz17ZMFSGMoOTC17Z9b5nE2Z4ZHjHM5EKhY0TlwzXFUuJAE9PhOfxF0wIO/maZSA=="
@@ -6372,6 +6387,11 @@
   "version" "1.6.0"
   dependencies:
     "prop-types" "^15.5.10"
+
+"react-native-text-ticker@1.14.0":
+  "integrity" "sha512-8TNGTcW43dfnCqIuXVA7F1Ny8SKGrw0pIrNS5nM7eda+6AsuPTZh3JQ2CwmSRYfsrlnS4QFrpyo5ykpI8nvtCw=="
+  "resolved" "https://registry.npmjs.org/react-native-text-ticker/-/react-native-text-ticker-1.14.0.tgz"
+  "version" "1.14.0"
 
 "react-native-track-player@2.1.2":
   "integrity" "sha512-tZw9/4Ft7EtKtWDZuregBEXjXv++7WT7BvaXDk+lKCL/e3FQI5zyiwECfM18sk6raeMs7ItBxNsDKryCf9mMUA=="
@@ -6419,7 +6439,7 @@
     "whatwg-fetch" "^3.0.0"
     "ws" "^6.1.4"
 
-"react-native@*", "react-native@^0.0.0-0 || ^0.60.6 || ^0.61.5 || ^0.62.2 || ^0.63.2 || ^0.64.0 || ^0.65.0 || ^0.66.0 || 1000.0.0", "react-native@^0.66.0", "react-native@>=0.40.0", "react-native@>=0.55", "react-native@>=0.60.0-rc.2", "react-native@0.66.0", "react-native@0.66.4":
+"react-native@*", "react-native@^0.0.0-0 || ^0.60.6 || ^0.61.5 || ^0.62.2 || ^0.63.2 || ^0.64.0 || ^0.65.0 || ^0.66.0 || 1000.0.0", "react-native@^0.66.0", "react-native@>=0.40.0", "react-native@>=0.55", "react-native@>=0.60.0-rc.2", "react-native@>=0.65.0", "react-native@0.66.0", "react-native@0.66.4":
   "integrity" "sha512-9vx5dlSfQlKbbDtr8+xMon6qsmSu7jvjdXWZpEKh3XVKpUidbbODv7048gwVKX8YAel1egeR7hN8vzSeI6ssTw=="
   "resolved" "https://registry.npmjs.org/react-native/-/react-native-0.66.4.tgz"
   "version" "0.66.4"


### PR DESCRIPTION
1. 피드와 관련된 컴포넌트, 스크린, 템플릿을 추가했어요.
- 스토리 확인, 스토리 추가 등은 현재 x
- 데일리, 플리로 넘어가는 것 현재 x

2. TrackPlayer providers는 App 전체에서 내려주다 필요한 부분에서만 내려주는 걸로 바꿨어요.

3. SongImage 부분 source에 uri를 추가했어요. (안드로이드 사진이 안보여서)

4. modal과 refresh providers를 추가 했어요.
- Modal 사용법은 HarmfulModal components를 보면 알 수 있어요.

5. 새로운 컴포넌트들을 추가했어요.

```LoadingIndicator```
- 기존과 동일

```MoveText```
- container: 가장 바깥 뷰를 담당 (텍스트가 움직일 width를 스타일로 주어야함)
- text: 담당 텍스트
- isMove: true시 텍스트 움직임
- isExplicit: 음악의 경우 true시 19세 아이콘 표시
- textStyle: text의 스타일 담당

```SongTitle```
- 19세 음악의 경우 아이콘을 바로 보여주기 위해 만든 컴포넌트
- isExplicit
- title
- titleStyle 
- 위와 동일

```Modal```
- 기본적인 Modal의 뼈대
- animation, backdropOpacity 기본값 지정

```HarmfulModal```
- 19세 음악 클릭시 나오는 모달
- 앞으로 모든 모달은 이러한 형태로 제작